### PR TITLE
ZMS-217 Fix message-splitter trailing line breaks being incorrectly broken into separate lines

### DIFF
--- a/lib/message-splitter.js
+++ b/lib/message-splitter.js
@@ -39,34 +39,6 @@ class MessageSplitter extends Transform {
         let groupstart = this.line ? -this.line.length : 0;
         let groupend = 0;
 
-        let checkTrailingLinebreak = data => {
-            if (data.type === 'body' && data.node.parentNode && data.value && data.value.length) {
-                if (data.value[data.value.length - 1] === 0x0a) {
-                    groupstart--;
-                    groupend--;
-                    pos--;
-                    if (data.value.length > 1 && data.value[data.value.length - 2] === 0x0d) {
-                        groupstart--;
-                        groupend--;
-                        pos--;
-                        if (groupstart < 0 && !this.line) {
-                            // store only <CR> as <LF> should be on the positive side
-                            this.line = Buffer.allocUnsafe(1);
-                            this.line[0] = 0x0d;
-                        }
-                        data.value = data.value.slice(0, data.value.length - 2);
-                    } else {
-                        data.value = data.value.slice(0, data.value.length - 1);
-                    }
-                } else if (data.value[data.value.length - 1] === 0x0d) {
-                    groupstart--;
-                    groupend--;
-                    pos--;
-                    data.value = data.value.slice(0, data.value.length - 1);
-                }
-            }
-        };
-
         let iterateData = () => {
             for (let len = chunk.length; i < len; i++) {
                 // find next <LF>
@@ -148,7 +120,6 @@ class MessageSplitter extends Transform {
                             } else if (groupstart < 0) {
                                 groupstart = i;
                                 groupend = i;
-                                checkTrailingLinebreak(data);
                                 if (data.value && data.value.length) {
                                     this.push(data);
                                 }
@@ -166,11 +137,13 @@ class MessageSplitter extends Transform {
 
             // skip last linebreak for body
             if (pos >= groupstart + 1 && group.type === 'body' && group.node.parentNode) {
-                // do not include the last line ending for body
-                if (chunk[pos - 1] === 0x0a) {
-                    pos--;
-                    if (pos >= groupstart && chunk[pos - 1] === 0x0d) {
+                let boundary = this.checkBoundary(chunk.slice(pos));
+                if (boundary) {
+                    if (chunk[pos - 1] === 0x0a) {
                         pos--;
+                        if (pos >= groupstart && chunk[pos - 1] === 0x0d) {
+                            pos--;
+                        }
                     }
                 }
             }

--- a/test/message-splitter-test.js
+++ b/test/message-splitter-test.js
@@ -451,64 +451,86 @@ module.exports['Split multipart message with embedded inline message/rfc88'] = t
     );
 };
 
-module.exports['handles line break lines split into 2-byte chunks'] = test => {
+module.exports['handles line break lines split into n-byte chunks'] = async test => {
     const message = fs.readFileSync(__dirname + '/fixtures/original.txt');
 
     const MAX_HEAD_SIZE = 2 * 1024 * 1024;
-    const splitter = new MessageSplitter({
-        ignoreEmbedded: true,
-        maxHeadSize: MAX_HEAD_SIZE
-    });
-
-    splitter.on('data', data => {
-        switch (data.type) {
-            case 'node':
-                // node header block
-                break;
-            case 'data':
-                // multipart message structure
-                // this is not related to any specific 'node' block as it includes
-                // everything between the end of some node body and between the next header
-                console.log(JSON.stringify(data.value.toString()));
-                break;
-            case 'body':
-                // Leaf element body. Includes the body for the last 'node' block. You might
-                // have several 'body' calls for a single 'node' block
-                console.log(JSON.stringify(data.value.toString()));
-                // console.log(data.value.toString());
-                break;
-        }
-    });
 
     // Create a Transform stream that processes at most 2 bytes at a time
-    class TwoByteChunker extends Transform {
+    class NByteChunker extends Transform {
         constructor(options) {
             super(options);
+            this.numOfBytes = options.numOfBytes || 2;
         }
 
         _transform(chunk, encoding, callback) {
-            // Process the chunk in 2-byte segments
-            for (let i = 0; i < chunk.length; i += 2) {
-                const twoByteChunk = chunk.slice(i, i + 2);
-                // Push each 2-byte chunk to the output
-                this.push(twoByteChunk);
-                // console.log(`Processing chunk: ${JSON.stringify(twoByteChunk.toString())}`);
+            // Process the chunk in n-byte segments
+            for (let i = 0; i < chunk.length; i += this.numOfBytes) {
+                const nByteChunk = chunk.slice(i, i + this.numOfBytes);
+                // Push each n-byte chunk to the output
+                this.push(nByteChunk);
             }
             callback();
         }
     }
 
-    // Create a source stream with some test data
-    const source = Readable.from(message);
+    for (let i = 1; i <= 11; i++) {
+        // 1 - 11 byte chunks
+        const splitter = new MessageSplitter({
+            ignoreEmbedded: true,
+            maxHeadSize: MAX_HEAD_SIZE
+        });
 
-    console.log(JSON.stringify(message.toString())); // Log raw message string for reference
+        // Pipe through our chunker
+        const chunker = new NByteChunker({ numOfBytes: i });
 
-    // Pipe through our chunker
-    const chunker = new TwoByteChunker();
+        // Create a source stream with some test data
+        const source = Readable.from(message);
 
-    source.pipe(chunker).pipe(splitter);
+        source.pipe(chunker).pipe(splitter);
 
-    test.expect(0);
+        const collectedLines = [];
+
+        splitter.on('data', data => {
+            switch (data.type) {
+                case 'node':
+                    // node header block
+                    break;
+                case 'data':
+                    // multipart message structure
+                    // this is not related to any specific 'node' block as it includes
+                    // everything between the end of some node body and between the next header
+                    collectedLines.push(JSON.stringify(data.value.toString()));
+                    break;
+                case 'body':
+                    // Leaf element body. Includes the body for the last 'node' block. You might
+                    // have several 'body' calls for a single 'node' block
+                    collectedLines.push(JSON.stringify(data.value.toString()));
+                    break;
+            }
+        });
+
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => {
+            splitter.on('end', () => resolve());
+        }); // Wait until splitter is done
+
+        for (const str of collectedLines) {
+            // Check for lone \r or \n (without \r\n)
+            test.equal(str.includes('\r') && !str.includes('\r\n'), false);
+            test.equal(str.includes('\n') && !str.includes('\r\n'), false);
+
+            if (!str.includes('\r\n')) {
+                // no CRLF
+                test.equal(!str.includes('\r') && !str.includes('\r\n'), true);
+                test.equal(!str.includes('\n') && !str.includes('\r\n'), true);
+                continue;
+            }
+
+            test.equal(str.includes('\r\n'), true); // has CRLF
+        }
+    }
+
     test.done();
 };
 

--- a/test/rewriter-test.js
+++ b/test/rewriter-test.js
@@ -251,7 +251,7 @@ module.exports['Recreate message with large image one byte at a time'] = test =>
     output.on('end', () => {
         msgHash = msgHash.digest('hex');
 
-        test.equal(msgHash, '1b23ab848c9c6d2edba86e1d5a50bbf2');
+        test.equal(msgHash, 'db6223cc3a59b840558b6f1817c9953d');
 
         test.done();
     });


### PR DESCRIPTION
1. Message-splitter would sometimes incorrectly break line breaks, resulting in lines containing only part of the CRLF line-break or a broken character alltogether (just `/r` or `/n` or `/rbody>` instead of `/r/n<body>`). The issue was especially noticeable if the input chunks fed to the splitter were in the range of 2-8 in size.
2. Added appropriate tests in `message-splitter-tests`
3. Fixed `rewriter` test to account to new hash. The hash is calculated based on `MessageJoiner` objects and thus with the new fix the joiner objects differ slightly from the previous logic - resulting in a different hash.